### PR TITLE
'T: Send' to prevent misuse of ReadTicket/WriteTicket

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub struct ReadTicket<T> {
     data: Arc<UnsafeCell<T>>,
 }
 
-unsafe impl<T> Send for ReadTicket<T> {}
+unsafe impl<T: Send> Send for ReadTicket<T> {}
 
 #[cfg(not(feature = "futures"))]
 impl<T> ReadTicket<T> {
@@ -112,7 +112,7 @@ pub struct WriteTicket<T> {
     data: Arc<UnsafeCell<T>>,
 }
 
-unsafe impl<T> Send for WriteTicket<T> {}
+unsafe impl<T: Send> Send for WriteTicket<T> {}
 
 #[cfg(not(feature = "futures"))]
 impl<T> WriteTicket<T> {


### PR DESCRIPTION
This PR fixes #7 by adding `T: Send` bounds to `Send` impls for both `ReadTicket` & `WriteTicket`.

Thank you for reviewing this PR :+1: 

p.s. 
After this fix is merged to master, would you mind publishing a new release to crates.io?